### PR TITLE
upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        scala: [2.12.18]
+        scala: [2.12.20]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,13 +41,13 @@ jobs:
           disk-root: 'C:'
 
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.18]
+        scala: [2.12.20]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -97,13 +97,13 @@ jobs:
           disk-root: 'C:'
 
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8
@@ -112,12 +112,12 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Download target directories (2.12.18)
-        uses: actions/download-artifact@v4
+      - name: Download target directories (2.12.20)
+        uses: actions/download-artifact@v5
         with:
-          name: target-${{ matrix.os }}-2.12.18-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.12.20-${{ matrix.java }}
 
-      - name: Inflate target directories (2.12.18)
+      - name: Inflate target directories (2.12.20)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -9,6 +9,9 @@ name: Clean
 
 on: push
 
+permissions:
+  actions: write
+
 jobs:
   delete-artifacts:
     name: Delete Artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
-val scala212 = "2.12.18"
+val scala212 = "2.12.20"
 
 ThisBuild / scalaVersion := scala212
 ThisBuild / crossScalaVersions := Seq(scala212)
@@ -75,15 +75,10 @@ lazy val pekkoPlugin = project
     addSbtPlugin(
       // When updating the sbt-paradox version,
       // remember to also update project/plugins.sbt
-      ("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").excludeAll(
-        "com.typesafe.sbt", "sbt-web",
-        "com.lightbend.paradox" % "sbt-paradox-apidoc",
-        "com.lightbend.paradox" % "sbt-paradox-project-info")),
-    addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.5"), // sbt-paradox 0.9.2 depends on old sbt-web 1.4.x, but we want a newer version
-    addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0").excludeAll(
-      "com.lightbend.paradox", "sbt-paradox")),
-    addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1").excludeAll(
-      "com.lightbend.paradox", "sbt-paradox")),
+      "com.lightbend.paradox" % "sbt-paradox" % "0.10.7"),
+    addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.8"),
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0"),
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1"),
     addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "0.7.0"),
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "pekko-paradox.properties"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.11.3
-
+sbt.version=1.11.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,12 +17,12 @@
 
 // When updating the sbt-paradox version,
 // remember to also update build.sbt
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-theme" % "0.9.2").exclude("com.typesafe.sbt", "sbt-web"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").exclude("com.typesafe.sbt", "sbt-web"))
-addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.5") // sbt-paradox[-theme] 0.9.2 depends on old sbt-web 1.4.x, but we want a newer version
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.7")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.7")
+addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.8")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.12")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
-addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.25.0")
+addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.28.0")


### PR DESCRIPTION
If and when we do a new release of this sbt plugin and our other projects uptake it, they will then not be able with Java 8 because some of the downstream plugins need newer versions of Java.